### PR TITLE
added std:: to become "std::ifstream"

### DIFF
--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -549,7 +549,7 @@ map<string, string> Utilities::readFASTA(std::string file, bool fullIdentifier)
 {
 	map<string, string> forReturn;
 
-	ifstream FASTAstream;
+	std::ifstream FASTAstream;
 
 	FASTAstream.open(file.c_str());
 	if(! FASTAstream.is_open())


### PR DESCRIPTION
Minor but important fix:

My understanding is that in new versions of boost, `ifstream` alone is ambiguous, and will give fatal errors upon compilation (to which I can attest). 

See "file streams" here: 
https://wiki.freebsd.org/BoostPortingProject/1.55-to-1.60

In the other parts of the code, `std::ifstream` is used. 